### PR TITLE
fix: update email domain and add site URL in metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,6 +22,7 @@ export const metadata: Metadata = {
 		siteName: "GradVerify",
 		type: "website",
 		title: "GradVerify",
+		url: "https://gc-gradverify.space",
 	},
 };
 

--- a/src/lib/utils/mailer.ts
+++ b/src/lib/utils/mailer.ts
@@ -13,7 +13,7 @@ export async function sendVerificationEmail(
 	const verifyUrl = `${baseUrl}/verify?token=${token}`;
 
 	await resend.emails.send({
-		from: "GradVerify <noreply@gc-gradverify.site>",
+		from: "GradVerify <noreply@gc-gradverify.space>",
 		to: email,
 		subject: "Verify Your Email",
 		react: VerifyEmailMessage({ verifyUrl: verifyUrl, name: name! }),


### PR DESCRIPTION
- Changed the email sender domain from "gc-gradverify.site" to "gc-gradverify.space" for consistency.
- Added the site URL "https://gc-gradverify.space" to the metadata for improved SEO and linking.